### PR TITLE
Add ZettaBlock to Infra Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A collection of live projects within the Aptos ecosystem.
 - Crust - [Github](https://github.com/crustio) | [Twitter](https://twitter.com/CrustNetwork) | [Website](https://crust.network/)
 - Pyth Network - [Github](https://github.com/pyth-network) | [Twitter](https://twitter.com/PythNetwork) | [Website](https://pyth.network/)
 - Wormhole - [Github](https://github.com/wormhole-foundation/wormhole) | [Twitter](https://twitter.com/wormholecrypto) | [Website](https://wormhole.com/)
+- ZettaBlock - [Twitter](https://twitter.com/ZettaBlockHQ) | [Website](https://www.zettablock.com/)
 
 ## Marketplace
 - BlueMove - [Twitter](https://twitter.com/BlueMove_OA) | [Website](https://bluemove.net/)


### PR DESCRIPTION
ZettaBlock provides infra for Aptos indexing and analytics service, and is one of the earliest to provide aptos data to the community

reference
- Artemis build dapps using ZettaBlock: https://twitter.com/Artemis__xyz/status/1587242764370120706 
- Aptos dashboard built using ZettaBock: https://app.zettablock.com/community/dashboards/da-0a841b95-b1d3-4d5a-af3b-ed2fc131e92c