### PR TITLE
Add ProtonSale to Launchpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ A collection of live projects within the Aptos ecosystem.
 - Rise Wallet - [Twitter](https://twitter.com/rise_wallet) | [Website](https://risewallet.io/)
 - Trust Wallet - [Github](https://github.com/trustwallet) | [Twitter](https://twitter.com/trustwallet) | [Website](https://trustwallet.com/)
 
+## Launchpad
+- Proton Sale - [Github](https://github.com/0xmodule/proton-sale) | [Twitter](https://twitter.com/protonsale_apt) | [Website](https://protonsale.io/)
 ---
 
 


### PR DESCRIPTION
Decentralized Launchpad
Running on Aptos testnet
Technical doc: https://docs.protonsale.io/important/nft-position