### PR TITLE
Remove Laminar Markets, acquired by Econia Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ A collection of live projects within the Aptos ecosystem.
 - Jujube Finance - [Github](https://github.com/jujubefinance) | [Twitter](https://twitter.com/JujubeFinance) | [Website](https://www.jujube.finance)
 - Kana Labs - [Twitter](https://twitter.com/kanalabs) | [Website](https://app.kanalabs.io/)
 - Koizumi - [Github](https://github.com/KoizumiAPT) | [Twitter](https://twitter.com/KoizumiAPT) | [Website](https://koizumi.io)
-- Laminar Markets - [Twitter](https://twitter.com/LaminarMarkets) | [Website](https://laminar.markets/)
 - Mole - [Github](https://github.com/Mole-Fi) | [Twitter](https://twitter.com/moledefi) | [Website](https://mole.fi/)
 - PancakeSwap - [Github](https://github.com/pancakeswap/) | [Twitter](https://twitter.com/pancakeswap) | [Website](https://aptos.pancakeswap.finance/swap)
 - Patronus - [Github](https://github.com/patronusfi) | [Twitter](https://twitter.com/Patronus_Fi) | [Website](https://patronus.fi/)


### PR DESCRIPTION
https://medium.com/econialabs/econia-labs-acquires-laminar-markets-7a8c82f51f64