### PR TITLE
Delete Forbitswap.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ A collection of live projects within the Aptos ecosystem.
 | Econia | [GitHub](https://github.com/econia-labs/econia) | [Twitter](https://twitter.com/EconiaLabs) | [Website](https://econialabs.com)
 | Ferum | [Github](https://github.com/ferum-dex/) | [Twitter](https://twitter.com/ferumxyz) | [Website](https://www.ferum.xyz/)
 | Foil Labs || [Twitter](https://twitter.com/foil_labs) | [Website](https://foil.so/)
-| Forbitswap || [Twitter](https://twitter.com/forbitswap) | [Website](https://forbitswap.com/)
 | HoustonSwap || [Twitter](https://twitter.com/Houston_swap) | [Website](https://houstonswap.io/)
 | Jujube Finance | [Github](https://github.com/jujubefinance) | [Twitter](https://twitter.com/JujubeFinance) | [Website](https://www.jujube.finance)
 | Kana Labs || [Twitter](https://twitter.com/kanalabs) | [Website](https://app.kanalabs.io/)


### PR DESCRIPTION
After doing a little investigation, came to the following:

1. The website (platform) is down. I suspect it has been down for a long time, however I have tried logging in for three days.
2. The project team does not communicate in discord and telegram.
3. the project is not associated with DeFi in any way, the activity over the last months (last announcements in May 2023) is more like an NFT collection or scam.


From which we can conclude that the project has closed or does not meet the high standards of the Aptos ecosystem.
